### PR TITLE
ENG-3411 Customer.search_transfers should return list of transfers and total transfers

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+[
+  inputs: ["mix.exs", "config/*.exs"],
+  subdirectories: ["apps/*"]
+]

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.13.4-otp-24
+erlang 24.3.3

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,3 @@
+import Config
+
+import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,4 @@
+import Config
+
+config :dwolla,
+  root_uri: "https://api-sandbox.dwolla.com/"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,4 @@
+import Config
+
+config :dwolla,
+  root_uri: "https://api.dwolla.com/"

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,6 @@
+import Config
+
+config :dwolla,
+  root_uri: "https://api-sandbox.dwolla.com/",
+  client_id: "test_id",
+  client_secret: "test_secret"

--- a/lib/dwolla/customer.ex
+++ b/lib/dwolla/customer.ex
@@ -222,7 +222,7 @@ defmodule Dwolla.Customer do
   %{start_date: "2017-04-01", end_date: "2017-04-30", status: "pending"}
   ```
   """
-  @spec search_transfers(token, id, params) :: {:ok, %{data: [Dwolla.Transfer.t], total: integer()}} | {:error, error}
+  @spec search_transfers(token, id, params) :: {:ok, %{transfers: [Dwolla.Transfer.t], total: integer()}} | {:error, error}
   def search_transfers(token, id, params \\ %{}) do
     endpoint =
       case Map.keys(params) do

--- a/lib/dwolla/customer.ex
+++ b/lib/dwolla/customer.ex
@@ -222,7 +222,7 @@ defmodule Dwolla.Customer do
   %{start_date: "2017-04-01", end_date: "2017-04-30", status: "pending"}
   ```
   """
-  @spec search_transfers(token, id, params) :: {:ok, [Dwolla.Transfer.t]} | {:error, error}
+  @spec search_transfers(token, id, params) :: {:ok, %{data: [Dwolla.Transfer.t], total: integer()}} | {:error, error}
   def search_transfers(token, id, params \\ %{}) do
     endpoint =
       case Map.keys(params) do

--- a/lib/dwolla/utils.ex
+++ b/lib/dwolla/utils.ex
@@ -155,7 +155,7 @@ defmodule Dwolla.Utils do
 
   defp map_body(%{"_embedded" => %{"transfers" => transfers}, "total" => total}, schema) do
     transfers = Enum.map(transfers, &map_body(&1, schema))
-    %{data: transfers, total: total}
+    %{transfers: transfers, total: total}
   end
 
   defp map_body(%{"_embedded" => %{"webhook-subscriptions" => webhook_subs}}, schema) do

--- a/lib/dwolla/utils.ex
+++ b/lib/dwolla/utils.ex
@@ -153,8 +153,9 @@ defmodule Dwolla.Utils do
     Enum.map(funding_sources, &map_body(&1, schema))
   end
 
-  defp map_body(%{"_embedded" => %{"transfers" => transfers}}, schema) do
-    Enum.map(transfers, &map_body(&1, schema))
+  defp map_body(%{"_embedded" => %{"transfers" => transfers}, "total" => total}, schema) do
+    transfers = Enum.map(transfers, &map_body(&1, schema))
+    %{data: transfers, total: total}
   end
 
   defp map_body(%{"_embedded" => %{"webhook-subscriptions" => webhook_subs}}, schema) do

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Dwolla.Mixfile do
   def project do
     [
       app: :dwolla,
-      version: "1.0.0",
+      version: "1.0.1",
       description: @description,
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env()),

--- a/test/lib/dwolla/customer_test.exs
+++ b/test/lib/dwolla/customer_test.exs
@@ -219,8 +219,8 @@ defmodule Dwolla.CustomerTest do
         Conn.resp(conn, 200, body)
       end
 
-      assert {:ok, resp} = Customer.search_transfers("token", "id", %{end_date: end_date})
-      assert Enum.empty?(resp)
+      assert {:ok, %{transfers: transfers, total: 0}} = Customer.search_transfers("token", "id", %{end_date: end_date})
+      assert Enum.empty?(transfers)
     end
 
     test "search_transfers/2 returns list when params are omitted", %{bypass: bypass} do
@@ -229,8 +229,8 @@ defmodule Dwolla.CustomerTest do
         Conn.resp(conn, 200, body)
       end
 
-      assert {:ok, resp} = Customer.search_transfers("token", "id")
-      assert Enum.empty?(resp)
+      assert {:ok, %{data: transfers, total: 0}} = Customer.search_transfers("token", "id")
+      assert Enum.empty?(transfers)
     end
 
     test "create_beneficial_owner/3 requests POST and returns id", %{bypass: bypass} do

--- a/test/lib/dwolla/customer_test.exs
+++ b/test/lib/dwolla/customer_test.exs
@@ -229,7 +229,7 @@ defmodule Dwolla.CustomerTest do
         Conn.resp(conn, 200, body)
       end
 
-      assert {:ok, %{data: transfers, total: 0}} = Customer.search_transfers("token", "id")
+      assert {:ok, %{transfers: transfers, total: 0}} = Customer.search_transfers("token", "id")
       assert Enum.empty?(transfers)
     end
 


### PR DESCRIPTION
`Customer.search_transfers/3` is a paginated API endpoint. In order to properly iterate through the pages of transfers, we need to know how many transfers there are total.

- Modify the response from `Customer.search_transfers/3` to return a map with list of transfers and total number of transfers rather than returning just the list of transfers. 
- Bump version from 1.0.0 to 1.0.1